### PR TITLE
Fixed absolute path to endpoint

### DIFF
--- a/profiles/dangular/modules/custom/angular/app/views.service.js
+++ b/profiles/dangular/modules/custom/angular/app/views.service.js
@@ -30,7 +30,7 @@ System.register(['angular2/core', 'angular2/http', 'rxjs/Rx'], function(exports_
                      *
                      * @type {string}
                      */
-                    this.baseUrl = '/dangular-endpoint/view';
+                    this.baseUrl = Drupal.url('dangular-endpoint/view');
                     this.options = new http_1.RequestOptions({
                         headers: new http_1.Headers({
                             // We'll get internal server errors without the proper Accept

--- a/profiles/dangular/modules/custom/angular/app/views.service.ts
+++ b/profiles/dangular/modules/custom/angular/app/views.service.ts
@@ -21,7 +21,7 @@ export class Views
      *
      * @type {string}
      */
-    private baseUrl = '/dangular-endpoint/view';
+    private baseUrl = Drupal.url('dangular-endpoint/view');
 
     /**
      * Base request options.


### PR DESCRIPTION
Absolute paths in views.service.\* path converted using Drupal.url
